### PR TITLE
Add Swagger UI to visualize contacts API

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -1,10 +1,15 @@
 const express = require("express");
 const cors = require("cors");
+const swaggerUI = require('swagger-ui-express');
+
+const contacts = require("./contacts");
+const openApiDocumentation = require('./oaSpecification');
+
 const app = express();
 
 app.use(cors());
 app.use(express.json());
-const contacts = require("./contacts");
+app.use('/api-docs', swaggerUI.serve, swaggerUI.setup(openApiDocumentation));
 
 app.get("/", contacts.index);
 app.get("/contacts", contacts.index);

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -360,6 +360,19 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
+    "swagger-ui-dist": {
+      "version": "3.32.5",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.32.5.tgz",
+      "integrity": "sha512-3SKHv8UVqsKKknivtACHbFDGcn297jkoZN2h6zAZ7b2yoaJNMaRadQpC3qFw3GobZTGzqHCgHph4ZH9NkaCjrQ=="
+    },
+    "swagger-ui-express": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.1.4.tgz",
+      "integrity": "sha512-Ea96ecpC+Iq9GUqkeD/LFR32xSs8gYqmTW1gXCuKg81c26WV6ZC2FsBSPVExQP6WkyUuz5HEiR0sEv/HCC343g==",
+      "requires": {
+        "swagger-ui-dist": "^3.18.1"
+      }
+    },
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",

--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,7 @@
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "lodash": "^4.17.19",
+    "swagger-ui-express": "^4.1.4",
     "uuid": "^8.2.0"
   }
 }


### PR DESCRIPTION
## Overview
This PR adds [Swagger UI](https://swagger.io/tools/swagger-ui/) to the Express backend. Swagger UI uses the [Open API spec file](https://github.com/remnantkevin/mobiz-assessment/blob/master/server/oaSpecification.json) to generate an interactive visualisation of the API, which is available at `/api-docs`.

## Future improvements
The Open API spec file should be improved to be more descriptive.